### PR TITLE
allow the parse of negative occupancy by revising the pattern

### DIFF
--- a/vasppy/procar.py
+++ b/vasppy/procar.py
@@ -7,11 +7,11 @@ ev_to_hartree = 0.036749309
 
 def get_numbers_from_string( string ):
     p = re.compile('-?\d+[.\d]*')
-    return [ float( s ) for s in p.findall( string ) ] 
+    return [ float( s ) for s in p.findall( string ) ]
 
 def k_point_parser( string ):
     regex = re.compile( 'k-point\s+\d+\s*:\s+((?:[- ][01].\d{8}){3})' )
-    return [ [ float(s) for s in [ x[0:11], x[11:22], x[22:33] ] ] for x in regex.findall( string ) ] 
+    return [ [ float(s) for s in [ x[0:11], x[11:22], x[22:33] ] ] for x in regex.findall( string ) ]
 
 def projections_parser( string ):
     regex = re.compile( '([-.\d\se]+tot.+)\n' )
@@ -23,7 +23,7 @@ def projections_parser( string ):
 def area_of_a_triangle_in_cartesian_space( a, b, c ):
     """
     Returns the area of a triangle defined by three points in Cartesian space.
-    
+
     Args:
         a (np.array): Cartesian coordinates of point A.
         b (np.array): Cartesian coordinates of point B.
@@ -39,7 +39,7 @@ def points_are_in_a_straight_line( points, tolerance=1e-7 ):
     Check whether a set of points fall on a straight line.
     Calculates the areas of triangles formed by triplets of the points.
     Returns False is any of these areas are larger than the tolerance.
-    
+
     Args:
         points (list(np.array)): list of Cartesian coordinates for each point.
         tolerance (optional:float): the maximum triangle size for these points to be considered colinear. Default is 1e-7.
@@ -58,9 +58,9 @@ def two_point_effective_mass( cartesian_k_points, eigenvalues ):
     """
     Calculate the effective mass given eigenvalues at two k-points.
     Reimplemented from Aron Walsh's original effective mass Fortran code.
-    
+
     Args:
-        cartesian_k_points (np.array): 2D numpy array containing the k-points in (reciprocal) Cartesian coordinates. 
+        cartesian_k_points (np.array): 2D numpy array containing the k-points in (reciprocal) Cartesian coordinates.
         eigenvalues (np.array):        numpy array containing the eigenvalues at each k-point.
 
     Returns:
@@ -140,9 +140,9 @@ class Procar:
     def parse_bands( self ):
         bands = re.findall( r"band\s*(\d+)\s*#\s*energy\s*([-.\d\s]+)", self.read_in )
         self.bands = np.array( bands, dtype = float )
-        
+
     def parse_occupancy(self):
-        occupancy = re.findall(r"band\s*(\d+)\s*#\s*energy\s*[-.\d\s]+\s*#\s"r"*occ.\s*([.\d\s]+)", self.read_in)
+        occupancy = re.findall(r"band\s*(\d+)\s*#\s*energy\s*[-.\d\s]+\s*#\s"r"*occ.\s*([-.\d\s]+)", self.read_in)
         self.occupancy = np.array(occupancy, dtype = float)
 
     def sanity_check( self ):
@@ -153,7 +153,7 @@ class Procar:
         read_bands = len( self.bands ) / self.number_of_k_points / self.k_point_blocks
         assert( expected_bands == read_bands ), "band mismatch: {} in header; {} in file".format( expected_bands, read_bands )
         read_occupancy = len(self.occupancy) / self.number_of_k_points / self.k_point_blocks
-        assert( expected_bands == read_occupancy ), "error parsing occupancy data: {} bands in file, {} occupancy data points".format( expected_bands, read_occupancy ) 
+        assert( expected_bands == read_occupancy ), "error parsing occupancy data: {} bands in file, {} occupancy data points".format( expected_bands, read_occupancy )
 
     def read_from_file( self, filename, bands_in_range = None ):
         with open( filename, 'r' ) as file_in:
@@ -177,7 +177,7 @@ class Procar:
         # note: correct k-spacing is already implemented in weighted_band_structure
         assert( self.bands.shape == ( self.number_of_bands * self.number_of_k_points, 2 ) )
         to_return = np.insert( band_energies, 0, range( 1, self.number_of_k_points + 1 ), axis = 1 )
-        return to_return 
+        return to_return
 
     def print_weighted_band_structure( self, spins = None, ions = None, orbitals = None, scaling = 1.0, e_fermi = 0.0, reciprocal_lattice = None ):
         if spins:
@@ -185,7 +185,7 @@ class Procar:
         else:
             spins = list( range( self.spin_channels ) )
         if not ions:
-            ions = [ self.number_of_ions ] 
+            ions = [ self.number_of_ions ]
         if not orbitals:
             orbitals = [ self.data.shape[-1]-1 ] # !! NOT TESTED YET FOR f STATES !!
         if self.calculation[ 'spin_polarised' ]:
@@ -193,7 +193,7 @@ class Procar:
         else:
             band_energies = self.bands[:,1:].reshape( self.number_of_k_points, self.number_of_bands ).T
         orbital_projection = np.sum( self.data[ :, :, :, :, orbitals ], axis = 4 )
-        ion_projection = np.sum( orbital_projection[ :, :, :, ions ], axis = 3 ) 
+        ion_projection = np.sum( orbital_projection[ :, :, :, ions ], axis = 3 )
         spin_projection = np.sum( ion_projection[ :, :, spins ], axis = 2 )
         x_axis = self.x_axis( reciprocal_lattice )
         for i in range( self.number_of_bands ):


### PR DESCRIPTION
Hi, Benjamin, thank you very much for your vasppy code firstly.

When I used Lucy's (@lucydot ) code 'effmass' very recently, I came to realize that VASP allowed the existence of negative occupancy if tetrahedron method (see forum discussions http://cms.mpi.univie.ac.at/vasp-forum/viewtopic.php?t=12532) or Methfessel-Paxton scheme (see the official guide http://cms.mpi.univie.ac.at/vasp/guide/node124.html) was used.

However, the current vasppy cannot parse the negative occupancy properly, it returns 'null' for those negative occupancies, and hence they cannot be converted to the floatings as expected by the code.
To parse the negative occupancy properly, I suggest using the pattern in my commit. [Here](https://github.com/yw-fang/vasppy/blob/experiment-procar/tests/test_procar_occ.ipynb), you can find a notebook demonstrating the difference between the pattern I used and the one used in vasppy. An example PROCAR with negative occupancy can be found [here](https://github.com/yw-fang/vasppy/tree/experiment-procar/tests/test_data).

To @lucydot:
Seeing that occupancy is an important quantity in your code 'effmass', I am not sure whether parsing negative occupancies bring side effect or not. If you worry about it, you can throw a warning when it encounters PROCAR with negative occupancies.

Thank you very much. 