### PR TITLE
Correct string comparisons

### DIFF
--- a/vasppy/configuration.py
+++ b/vasppy/configuration.py
@@ -41,7 +41,7 @@ class Configuration:
         atoms_j = list( self.atoms_with_label( spec_j ) )
         for atom_i in atoms_i:
             for atom_j in atoms_j:
-                if atom_i is atom_j:
+                if atom_i == atom_j:
                     continue
                 dr = self.minimum_image_dr( atom_i, atom_j )
                 if dr <= max_r:
@@ -55,7 +55,7 @@ class Configuration:
         for atom_i in atoms_i:
             this_rdf = rdf.Rdf( max_r, number_of_bins )
             for atom_j in atoms_j:
-                if atom_i is atom_j:
+                if atom_i == atom_j:
                     continue
                 dr = self.minimum_image_dr( atom_i, atom_j )
                 try:

--- a/vasppy/doscar.py
+++ b/vasppy/doscar.py
@@ -178,11 +178,11 @@ class Doscar:
         to_return = self.pdos[atom_idx, :, :, :]
         if not spin:
             spin_idx = list(range(self.ispin))
-        elif spin is 'up':
+        elif spin == 'up':
             spin_idx = [0]
-        elif spin is 'down':
+        elif spin == 'down':
             spin_idx = [1]
-        elif spin is 'both':
+        elif spin == 'both':
             spin_idx = [0, 1]
         else:
             raise ValueError(

--- a/vasppy/doscar.py
+++ b/vasppy/doscar.py
@@ -261,7 +261,7 @@ class Doscar:
 
         for species in to_plot.keys():
             assert isinstance(self.species, Iterable)
-            index = [i for i, s in enumerate(self.species) if s is species]
+            index = [i for i, s in enumerate(self.species) if s == species]
             for state in to_plot[species]:
                 assert state in ['s', 'p', 'd', 'f']
                 color = next(color_iterator)

--- a/vasppy/neighbour_list.py
+++ b/vasppy/neighbour_list.py
@@ -85,10 +85,10 @@ class NeighbourList(object):
         """                   
         indices_i = [i for i, site in 
                      enumerate(structure)
-                     if site.species_string is species_i]
+                     if site.species_string == species_i]
         indices_j = [j for j, site in 
                      enumerate(structure)
-                     if site.species_string is species_j]
+                     if site.species_string == species_j]
         return cls(structure=structure,
                    indices_i=indices_i,
                    indices_j=indices_j,

--- a/vasppy/rdf.py
+++ b/vasppy/rdf.py
@@ -125,12 +125,18 @@ class RadialDistributionFunction(object):
         indices_j: Optional[List[int]]
 
         indices_i = [i for i, site in 
-                     enumerate(structures[0]) if site.species_string is species_i]
+                     enumerate(structures[0]) if site.species_string == species_i]
         if species_j:
             indices_j = [j for j, site in 
-                         enumerate(structures[0]) if site.species_string is species_j]
+                         enumerate(structures[0]) if site.species_string == species_j]
         else:
             indices_j = None
+  
+        if not indices_i:
+            raise ValueError('Species i not found.')
+        if not indices_j:
+            raise ValueError('Species j not found.')
+
         return cls(structures=structures, 
                    indices_i=indices_i, 
                    indices_j=indices_j, 


### PR DESCRIPTION
Replaces comparison of object ids (i.e., memory addresses) with string comparisons, as the former can lead to unstable behaviour.
For reference, please see https://lerner.co.il/2015/06/16/why-you-should-almost-never-use-is-in-python/